### PR TITLE
docs(readme): remove broken link to USAGE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This project provides a pre-commit hook for AI-assisted code reviews using the O
     pre-commit run ai-review --all-files
     ```
 
-For more detailed usage instructions, including pre-push setup and command-line options, please see the [Usage Guide](USAGE.md).
 
 ## Features
 


### PR DESCRIPTION
The USAGE.md file does not exist in the repository, so the link to it in the README.md was broken. This commit removes the sentence containing the broken link.